### PR TITLE
Add credentials update feature and startup checks

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,8 +16,11 @@ pidfile = decky_plugin.DECKY_PLUGIN_RUNTIME_DIR + "/decky-filebrowser.pid"
 # Strings useful for starting File Browser
 filebrowser_bin = decky_plugin.DECKY_PLUGIN_DIR + "/bin/filebrowser"
 filebrowser_database_path = decky_plugin.DECKY_PLUGIN_SETTINGS_DIR + "/filebrowser.db"
+filebrowser_settings_path = decky_plugin.DECKY_PLUGIN_SETTINGS_DIR + "/settings.json"
 filebrowser_cert_path = decky_plugin.DECKY_PLUGIN_DIR + "/bin/certs/cert.pem"
 filebrowser_key_path = decky_plugin.DECKY_PLUGIN_DIR + "/bin/certs/key.pem"
+filebrowser_default_port = 8082
+filebrowser_default_address = "0.0.0.0"
 
 # Load user's settings
 settings = SettingsManager(name="settings", settings_directory=settings_dir)
@@ -56,32 +59,29 @@ class Plugin:
             if os.path.exists(pidfile):
                 decky_plugin.logger.info("The server has already been started. Stopping it first.")
                 await self.stopFileBrowser( self )
+
+            if(port is None or (isinstance(port, str) and not port.isdigit())):
+                decky_plugin.logger.warning("Port Number is not numeric, resetting it.")
+                settings.setSetting( "port", filebrowser_default_port )
+
+            if not self.is_port_free(port):
+                msg = f"Port {port} is already in use."
+                decky_plugin.logger.warning("The server could not be started: " + msg)
+                return {
+                    "status": "error",
+                    "output": msg
+                }
             
-            if(isinstance(port, str) and not port.isdigit()):
-                decky_plugin.logger.info("Port Number is not numeric, resetting it.")
-                await self.reset_settings( self )
-                port = await self.get_setting( self, "port")
 
-            command = (
-                filebrowser_bin +
-                " -p " + str(port) +
-                " -a 0.0.0.0" +
-                " -d " + filebrowser_database_path +
-                " -t " + filebrowser_cert_path +
-                " -k " + filebrowser_key_path +
-                " -r " + decky_plugin.DECKY_USER_HOME
-            )
-
+            command = f"{filebrowser_bin} -c {filebrowser_settings_path}"
             decky_plugin.logger.info("Running FileBrowser command: " + command)
+
             process = await asyncio.create_subprocess_shell(command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
-            
-
-            settings.setSetting("port", port)
-
-            with open(pidfile, "w+") as file:
-                file.write(str(process.pid))
+            await asyncio.sleep(0.2) # This is needed since the file browser needs some time to start the process and show errors
 
             if(process.returncode is None):
+                with open(pidfile, "w+") as file:
+                    file.write(str(process.pid))
                 decky_plugin.logger.info(f"The server is running. Process ID is: {process.pid}")
                 return {
                     "status": "online",
@@ -89,9 +89,11 @@ class Plugin:
                 }
             else:
                 decky_plugin.logger.error("The server could not be started.")
+                stdout = await process.stdout.read(300)
+                decky_plugin.logger.error(stdout.decode("utf-8"))
                 return {
                     "status": "offline",
-                    "output": output_str
+                    "output": "none"
                 }
         except Exception as e:
             decky_plugin.logger.error(e)
@@ -101,7 +103,10 @@ class Plugin:
         try:
             if not os.path.exists(pidfile):
                 decky_plugin.logger.info("No server is currently running (no pidfile found).")
-                return
+                return {
+                    "status": "offline",
+                    "output": "none"
+                }
 
             with open(pidfile, "r") as file:
                 pid_str = file.read().strip()
@@ -138,27 +143,121 @@ class Plugin:
     async def logInfo( self, msg = "Javascript: no content" ):
         decky_plugin.logger.info(msg)
 
+
     async def logError( self, msg = "Javascript: no content" ):
         decky_plugin.logger.error(msg)
 
+
     async def get_setting( self, key ):
         return settings.getSetting( key )
+    
 
     async def save_user_settings( self, key: str, value ):
         decky_plugin.logger.info("Changing settings - {}: {}".format( key, value ))
         return settings.setSetting( key, value )
+    
+    
+    async def save_username_password( self, username: str, password: str):
+        try:
+            if(username is None or username == ""):
+                raise Exception(f"The username field was not provided.")
+            
+            if(password is None or password == ""):
+                raise Exception(f"The password field was not provided.")
+            
+            oldUsername = settings.getSetting("currentUsername")
+            newUsername = username
+            newPassword = password
+
+            decky_plugin.logger.warning(f"Saving new credentials for user: {oldUsername}.")
+            command = f'{filebrowser_bin} users update "{oldUsername}" -d "{filebrowser_database_path}" -u "{username}" -p "{newPassword}"'
+            process = await asyncio.create_subprocess_shell(command, shell=True, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+            
+            output, error = await process.communicate()
+            output_str = output.decode("utf-8")
+            output2_str = error.decode("utf-8")
+
+            if(output_str == ""):
+                decky_plugin.logger.info(output2_str)
+                raise Exception("Could not change the user credentials, please verify if the current username is correct in the JSON settings file.")
+            
+            settings.setSetting( "currentUsername", newUsername)
+            decky_plugin.logger.warning("New credentials were saved successfully.")
+            return {
+                "output": "success"
+            }
+        except Exception as e:
+            decky_plugin.logger.error("Could not fully save settings. Please verify what went wrong.")
+            decky_plugin.logger.error(e)
+
+
+    async def hashString( self, text: str ):
+        command = f"{filebrowser_bin} hash {text}"
+        process = await asyncio.create_subprocess_shell(command, shell=True, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+        output, error = await process.communicate()
+        output_str = output.decode("utf-8")
+        error_str = error.decode("utf-8")
+        if(error_str != ""):
+            raise Exception("Could not hash the given string.")
+        decky_plugin.logger.info(f"generated hash: {output_str}")
+        return output_str
+        
 
     async def reset_settings( self ):
-        settings.setSetting( "port", 8082 )
+        settings.setSetting( "port", filebrowser_default_port )
+        settings.setSetting( "address", filebrowser_default_address)
+        settings.setSetting( "database", filebrowser_database_path)
+        settings.setSetting( "key", filebrowser_key_path)
+        settings.setSetting( "cert", filebrowser_cert_path)
+
+
+    async def filebrowser_init( self ):
+        command = f"{filebrowser_bin} -c {filebrowser_settings_path}"
+        process = await asyncio.create_subprocess_shell(command, shell=True, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+        await asyncio.sleep(0.2)
+        process.kill()
+        decky_plugin.logger.info("Filebrowser database was successfully initialized.")
+        return "success"
+    
+
+    def is_port_free(port):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            return s.connect_ex(('localhost', port)) != 0
+
+
+    async def check_settings( self ):
+        try:
+            test = settings.getSetting("port")
+            test_2 = settings.getSetting("address")
+            test_3 = settings.getSetting("database")
+            if any(var is None for var in [test, test_2, test_3]):
+                decky_plugin.logger.warning("Could not find the configurations for file browser, recreating it with default values.")
+                await self.reset_settings(self)
+            
+            if not os.path.exists(filebrowser_database_path):
+                settings.setSetting( "currentUsername", "admin")
+                decky_plugin.logger.warning("Filebrowser database file not found. Initializing a new database...")
+                await self.filebrowser_init(self)
+                decky_plugin.logger.warning("The username and password was set to 'admin'. It is advisable to change it.")
+        except Exception as e:
+            decky_plugin.logger.error("Could not fully set the configurations for file browser. It may not work properly.")
+            decky_plugin.logger.error(e)
+
 
     # Asyncio-compatible long-running code, executed in a task when the plugin is loaded
     async def _main(self):
         decky_plugin.logger.info("Hello World!")
         if os.path.exists(pidfile):
             os.remove(pidfile)
+        decky_plugin.logger.info("Running settings check for the file browser...")
+        await self.check_settings(self)
+
 
     # Function called first during the unload process, utilize this to handle your plugin being removed
     async def _unload(self):
+        if os.path.exists(pidfile):
+            decky_plugin.logger.info("Closing DeckyFileBrowser. Stopping server instance...")
+            self.stopFileBrowser(self)
         decky_plugin.logger.info("Goodbye World!")
         pass
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,10 +1,11 @@
 {
   "name": "DeckyFileBrowser",
-  "author": "Heyde Moura",
+  "author": "Willyscoiote",
+  "originalCreator": "Heyde Moura",
   "flags": [],
   "publish": {
     "tags": [ "files", "server" ],
     "description": "Send and download files to your Steam Deck from a browser.",
-    "image": "https://opengraph.githubassets.com/1/heydemoura/decky-filebrowser-plugin"
+    "image": "https://opengraph.githubassets.com/1/barrence01/new-decky-filebrowser-plugin"
   }
 }

--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -4,6 +4,7 @@ import {
   TextField,
   PanelSection,
   PanelSectionRow,
+  ScrollPanel
 } from "decky-frontend-lib";
 import { AppContext } from "./utils/app-context";
 
@@ -11,31 +12,70 @@ const Settings = () => {
   // @ts-ignore
   const { fileBrowserManager } = useContext(AppContext);
   const [port, setPort] = useState( null );
+  const [username, setUsername] = useState( null );
+  const [password, setPassword] = useState( null );
   const [isSaving, setIsSaving] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [invalidPortError, setInvalidPortError] = useState(false);
-  const [errorMessage, setErrorMessage] = useState("");
-  const [successMessage, setSuccessMessage] = useState("");
+  const [invalidUsernameError, setInvalidUsernameError] = useState(false);
+  const [invalidPasswordError, setInvalidPasswordError] = useState(false);
+  const [portErrorMessage, setPortErrorMessage] = useState("");
+  const [portSuccessMessage, setPortSuccessMessage] = useState("");
+  const [usernamePasswordErrorMessage, setUsernamePasswordErrorMessage] = useState("");
+  const [usernamePasswordSuccessMessage, setUsernamePasswordSuccessMessage] = useState("");
 
-  const handleSave = useCallback(async () => {
+  const handleSavePort = useCallback(async () => {
 
     if(!port) {
-      showError("The field cannot be empty.")
+      showError("port", "The field cannot be empty.");
+      setInvalidPortError(true);
       return;
     }
 
     setIsSaving(true);
     if(!invalidPortError) {
       await fileBrowserManager.setPort(+port);
-      showSuccess("Port Number saved successfully.");
+      showSuccess("port", "Port number saved successfully.");
     }
     
     setIsSaving(false);
   }, [port, invalidPortError]);
 
+  const handleSaveUsernamePassword = useCallback(async () => {
+
+    if(!username && !password) {
+      showError("usernameAndPassword", "The fields cannot be empty.");
+      return;
+    }
+    if(!username) {
+      showError("usernameAndPassword", "The username field cannot be empty.");
+    }
+
+    if(!password) {
+      showError("usernameAndPassword", "The password field cannot be empty.");
+    }
+
+    if(!username || !password) {
+      return;
+    }
+
+    setIsSaving(true);
+    if(!invalidUsernameError && !invalidPasswordError) {
+      const result = await fileBrowserManager.saveUsernamePassword(username, password);
+
+      if(result == "success"){
+        showSuccess("usernameAndPassword", "Credentials changed successfully.");
+        return;
+      }
+      showError("usernameAndPassword", "Could not save credentials, check the logs for more details.");
+    }
+    
+    setIsSaving(false);
+  }, [username, password, invalidUsernameError, invalidPasswordError]);
+
   const handlePortChange = (e) => {
     setPort(e.target.value);
-    showError("");
+    showError("port", "");
     setInvalidPortError(true);
 
     if(!e.target.value) {
@@ -48,48 +88,119 @@ const Settings = () => {
 
     const isNumeric = !isNaN(+e.target.value)
     if (!isNumeric) {
-      showError("The field must be numeric.")
+      showError("port", "The port number must be numeric.")
       return;
     }
     const portNumber = +e.target.value;
 
     // Decky uses port 1337
     if (portNumber == 1337) {
-      showError("The port number 1337 cannot be used because it's already being used by decky.")
+      showError("port", "The port number 1337 cannot be used because it's already being used by decky.")
       return;
     }
 
     // To use a port equal or lower than 1024 on Linux, you need root access
     if(portNumber < 1024) {
-      showError("The port number must be higher than 1024.")
+      showError("port", "The port number must be higher than 1024.")
       return;
     }
     if(portNumber > 65535) {
-      showError("The port number must be lower than 65536.")
+      showError("port", "The port number must be lower than 65536.")
       return;
     }
 
     setInvalidPortError(false);
   };
 
-  const showError = (message: string) => {
-    setSuccessMessage("");
-    setErrorMessage(message);
+  const handleUsernameChange = (e) => {
+    handleUsernamePasswordChange("username", setUsername, setInvalidUsernameError, e.target.value)
   };
 
-  const showSuccess = (message: string) => {
-    setErrorMessage("");
-    setSuccessMessage(message);
-    setTimeout(() => {
-      setSuccessMessage("");
-    }, 3000);
+  const handlePasswordChange = (e) => {
+    handleUsernamePasswordChange("password", setPassword, setInvalidPasswordError, e.target.value)
   };
+
+  const handleUsernamePasswordChange = (field: string, setCallback: any, setInvalidCallback: any, fieldValue: any) => {
+    setCallback(fieldValue);
+    showError("usernameAndPassword", "");
+    setInvalidCallback(true);
+
+    if(!fieldValue) {
+      return;
+    }
+    const formValue = fieldValue.trim()
+
+    if (formValue.length > 20) {
+      setCallback(formValue.substring(0, 20));
+      return;
+    }
+
+    if (formValue.length < 4) {
+      showError("usernameAndPassword", "The " + field + " length can't be less than 4 characters.")
+      return;
+    }
+
+    if (!isValidForShell(formValue)) {
+      showError("usernameAndPassword", "The " + field + "cannot have the following characters: ;, |, &, >, <, \, *, ', `," + '".')
+      return;
+    }
+
+    setInvalidCallback(false);
+  };
+
+  const isValidForShell = (input: string) => {
+    const invalidChars = /[;&|><`'"\\$*?{}()\[\]\n\r]/;
+    return !invalidChars.test(input);
+  }
+
+  const showError = (field: string, message: string) => {
+
+    switch(field) {
+      case "port":
+        setPortSuccessMessage("");
+        setPortErrorMessage(message);
+        break;
+      case "usernameAndPassword":
+        setUsernamePasswordSuccessMessage("");
+        setUsernamePasswordErrorMessage(message);
+        window.scrollBy({ top: -30, behavior: 'smooth' });
+        break;
+      default:
+        break;
+    }
+  };
+
+  const showSuccess = (field: string, message: string) => {
+
+    switch(field) {
+      case "port":
+        setPortErrorMessage("");
+        setPortSuccessMessage(message);
+        setTimeoutClearMessage(setPortSuccessMessage);
+        break;
+      case "usernameAndPassword":
+        setUsernamePasswordErrorMessage("");
+        setUsernamePasswordSuccessMessage(message);
+        setTimeoutClearMessage(setUsernamePasswordSuccessMessage);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const setTimeoutClearMessage = (functionCallback: any) => {
+    setTimeout(() => { 
+      functionCallback("");
+    }, 3000);
+  }
 
   useEffect(() => {
     const loadDefaults = async () => {
       setIsLoading(true);
       const _port = await fileBrowserManager.getPortFromSettings();
       setPort(_port);
+      const _username = await fileBrowserManager.getUsernameFromSettings();
+      setUsername(_username);
       setIsLoading(false);
     };
 
@@ -97,44 +208,82 @@ const Settings = () => {
   }, []);
 
   return (
-    <div style={{ marginTop: "50px", color: "white" }}>
-      {isLoading ? (
-        <div style={{ textAlign: "center" }}>
-          <h2>Loading...</h2>
-        </div>
-      ) : (
-        <PanelSection title="File Browser options">
-          <PanelSectionRow>
-            <TextField
-              label="Port"
-              description="TCP port used for connection. The port number 1337 cannot be used because of decky."
-              onChange={handlePortChange}
-              value={port}
-              style={{
-                border: invalidPortError ? "1px red solid" : undefined,
-              }}
-            />
-            {errorMessage && (
-              <div style={{ color: 'red', fontWeight: '300' }}>
-                {errorMessage}
+    <ScrollPanel style={{ marginTop: "50px", marginBottom: "30px", color: "white" }}>
+      
+        {isLoading ? (
+              <div style={{ textAlign: "center" }}>
+                <h2>Loading...</h2>
               </div>
-            )}
-            {successMessage && (
-            <PanelSectionRow>
-              <div style={{ color: 'green', fontWeight: 'bold' }}>
-                {successMessage}
-              </div>
-            </PanelSectionRow>
-            )}
-          </PanelSectionRow>
-          <PanelSectionRow>
-            <ButtonItem onClick={handleSave} disabled={isSaving}>
-              Save
-            </ButtonItem>
-          </PanelSectionRow>
-        </PanelSection>
-      )}
-    </div>
+        ) : (
+            <PanelSection title="File Browser options" style={{ marginTop: "100px", marginBottom: "30px", color: "white"}}>
+              <PanelSectionRow>
+                <TextField
+                  label="Port"
+                  description="TCP port used for connection. The port number 1337 cannot be used because of decky."
+                  onChange={handlePortChange}
+                  value={port}
+                  style={{
+                    border: invalidPortError ? "1px red solid" : undefined, marginBottom: "0px"
+                  }}
+                />
+                {portErrorMessage && (
+                  <div style={{ color: 'red', fontWeight: '300' }}>
+                    {portErrorMessage}
+                  </div>
+                )}
+                {portSuccessMessage && (
+                  <div style={{ color: 'green', fontWeight: 'bold' }}>
+                    {portSuccessMessage}
+                  </div>
+                )}
+                <PanelSectionRow>
+                  <ButtonItem onClick={handleSavePort} disabled={isSaving}>
+                    Save
+                  </ButtonItem>
+                </PanelSectionRow>
+              </PanelSectionRow>
+
+              <PanelSectionRow>
+                <TextField
+                  label="Username"
+                  description="Set the username for the file browser."
+                  onChange={handleUsernameChange}
+                  value={username}
+                  style={{
+                    border: invalidUsernameError ? "1px red solid" : undefined
+                  }}
+                />
+              </PanelSectionRow>
+
+              <PanelSectionRow>
+                <TextField
+                  label="Password"
+                  description="Set the password for the file browser."
+                  onChange={handlePasswordChange}
+                  value={password}
+                  style={{
+                    border: invalidPasswordError ? "1px red solid" : undefined
+                  }}
+                />
+                {usernamePasswordErrorMessage && (
+                  <div style={{ color: 'red', fontWeight: '300' }}>
+                    {usernamePasswordErrorMessage}
+                  </div>
+                )}
+                {usernamePasswordSuccessMessage && (
+                  <div style={{ color: 'green', fontWeight: 'bold' }}>
+                    {usernamePasswordSuccessMessage}
+                  </div>
+                )}
+                <PanelSectionRow>
+                  <ButtonItem onClick={handleSaveUsernamePassword} disabled={isSaving}>
+                    Save
+                  </ButtonItem>
+                </PanelSectionRow>
+              </PanelSectionRow>
+            </PanelSection>
+        )}
+    </ScrollPanel>
   );
 };
 

--- a/src/state/filebrowser-manager.tsx
+++ b/src/state/filebrowser-manager.tsx
@@ -50,6 +50,16 @@ export default class FileBrowserManager {
     }
   }
 
+  async getUsernameFromSettings() {
+    const result = await this.serverAPI.callPluginMethod("get_setting", { key: "currentUsername" });
+
+    if ( result.result ) {
+      return result.result;
+    } else {
+      return "";
+    }
+  }
+
   async setPort(port: Number) {
     const result = await this.serverAPI.callPluginMethod("save_user_settings", { key: "port", value: port });
 
@@ -97,11 +107,21 @@ export default class FileBrowserManager {
     return await this.serverAPI.callPluginMethod("stopFileBrowser");
   }
 
+  async saveUsernamePassword(newUsername: string, newPassword: string) {
+    const result = await this.serverAPI.callPluginMethod("save_username_password", { username: newUsername, password: newPassword });
+
+    try{
+      return result.result?.output;
+    } catch (error) {
+      return "failed";
+    }
+  }
+
   async fileBrowserSendLogInfo( text: string ) {
-    return await this.serverAPI.callPluginMethod("logInfo", { msg: "Javascript:" + text });
+    return await this.serverAPI.callPluginMethod("logInfo", { msg: "Javascript: " + text });
   }
 
   async fileBrowserSendLogError( text: string ) {
-    return await this.serverAPI.callPluginMethod("logError", { msg: "Javascript:" + text });
+    return await this.serverAPI.callPluginMethod("logError", { msg: "Javascript: " + text });
   }
 }


### PR DESCRIPTION
* Added the ability for users to change their credentials (username and password) for authenticating in the file browser, accessible via the "Go to settings" option.

* Implemented a file check at plugin startup to ensure the creation of necessary settings files (e.g., default port, default user 'admin', and the database file).

* Introduced a check to verify if the selected port is free or already in use before starting the file browser server, preventing conflicts.